### PR TITLE
2708 helpscout gmaps

### DIFF
--- a/.git-ftp-ignore
+++ b/.git-ftp-ignore
@@ -5,3 +5,4 @@ requirements.txt
 tests/*
 phpunit.xml
 .travis.yml
+wp-content/themes/readme.md

--- a/wp-content/themes/gijn/inc/member-directory.php
+++ b/wp-content/themes/gijn/inc/member-directory.php
@@ -451,7 +451,7 @@ function network_member_alpha_links() {
  * Make WP_Query support title_starts_with
  */
 add_filter( 'posts_where', 'network_title_starts_with', 10, 2 );
-function network_title_starts_with( $where, &$wp_query ) {
+function network_title_starts_with( $where, $wp_query ) {
   global $wpdb;
   //needs to handle digits, ugh
   if ( $title_starts_with = $wp_query->get( 'title_starts_with' ) ) {

--- a/wp-content/themes/gijn/inc/member-directory.php
+++ b/wp-content/themes/gijn/inc/member-directory.php
@@ -177,7 +177,11 @@ function network_geocode_member( $post_id ) {
 
 	// Try to geocode it
 	$ch = curl_init();
-	$curl_url = "http://maps.googleapis.com/maps/api/geocode/json?address=" . $post_address . "&sensor=false";
+	$curl_url = sprintf(
+		'https://maps.googleapis.com/maps/api/geocode/json?address=%1$s&key=%2$s',
+		$post_address,
+		of_get_option( 'google_maps_api_key' )
+	);
 	curl_setopt($ch, CURLOPT_HEADER, 0);
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 	curl_setopt($ch, CURLOPT_URL, $curl_url);
@@ -191,6 +195,7 @@ function network_geocode_member( $post_id ) {
 	} else {
 		update_post_meta( $post_id, 'network_coords', '' );
 		//TO DO: display error message on geocode fail
+		error_log(var_export( $result, true));
 		add_filter( 'redirect_post_location', 'network_geocode_error' );
 	}
 }

--- a/wp-content/themes/gijn/inc/options.php
+++ b/wp-content/themes/gijn/inc/options.php
@@ -1,17 +1,30 @@
 <?php
+
+/**
+ * Extend the Largo settings page to add more options
+ */
 function gijn_custom_options($options) {
 	// tacking this option on to the end of the theme options
 	$options[] = array(
 		'name' => __('GIJN Options', 'gijn'),
-		'type' => 'heading');
+		'type' => 'heading'
+	);
+	$options[] = array(
+		'desc' 	=> __('<strong>Google Maps API key</strong> (Used for geocoding member locations, for <a href="https://gijn.org/member/">gijn.org/member</a>https://po.missouri.edu/cgi-bin/wa?A0=GLOBAL-L)', 'gijn'),
+		'id' 	=> 'google_maps_api_key',
+		'std' 	=> '',
+		'type' 	=> 'text'
+	);
 	$options[] = array(
 		'name' => __('Additional Social Links', 'gijn'),
-		'type' => 'info');
+		'type' => 'info'
+	);
 	$options[] = array(
 		'desc' 	=> __('<strong>Link for GIJN Listserv</strong> (https://po.missouri.edu/cgi-bin/wa?A0=GLOBAL-L)', 'gijn'),
 		'id' 	=> 'listserv_link',
 		'std' 	=> '',
-		'type' 	=> 'text');
+		'type' 	=> 'text'
+	);
 	return $options;
 }
 add_filter('largo_options', 'gijn_custom_options');

--- a/wp-content/themes/readme.md
+++ b/wp-content/themes/readme.md
@@ -1,0 +1,9 @@
+## Themes
+- `asia/` - uncoveringasia.org, depends on `largo_old`
+- `gijc/` - gijc2013.org, gijc2017.org, depends on `largo_old`
+- `gijc2015/`- depends on `largo`
+- `gijc_br/` - depends on `largo_old`
+- `gijn-impact/` - impact.gijn.org, depends on `largo`
+- `gijn/` - gijn.org, cn.gijn.org, depends on `largo`
+- `largo/` - Largo 0.5.5.4
+- `largo_old/` - Largo 0.1, which is to say pre-Largo-0.3

--- a/wp-content/themes/readme.md
+++ b/wp-content/themes/readme.md
@@ -6,4 +6,4 @@
 - `gijn-impact/` - impact.gijn.org, depends on `largo`
 - `gijn/` - gijn.org, cn.gijn.org, depends on `largo`
 - `largo/` - Largo 0.5.5.4
-- `largo_old/` - Largo 0.1, which is to say pre-Largo-0.3
+- `largo_old/` - Largo 0.1, which is to say pre-Largo-0.3. Depends on `bwp-google-xml-sitemaps` plugin.


### PR DESCRIPTION
## Changes

- adds Theme Options field for API key input
- uses that API key for geocoding
- does not modify the existing API key used for the map at https://gijn.org/member/
- adds some in-repo docs for which child theme uses which parent theme
- adds logging of geocoding API errors

## Why

For https://secure.helpscout.net/conversation/688210829/2708/