### PR TITLE
Use of_get_option rather than get_option to retrieve the API key that was set with of_set_option

### DIFF
--- a/wp-content/themes/gijn/inc/member-directory.php
+++ b/wp-content/themes/gijn/inc/member-directory.php
@@ -336,7 +336,7 @@ class members_widget extends WP_Widget {
 function network_member_map() {
 
 	$members = get_members();
-	$api_key = get_option( 'google_maps_api_key_frontend', 'AIzaSyD82h0mNBtvoOmhC3N4YZwqJ_xLkS8yTuw' );
+	$api_key = of_get_option( 'google_maps_api_key_frontend', 'AIzaSyD82h0mNBtvoOmhC3N4YZwqJ_xLkS8yTuw' );
 	?>
 	<div id="map-container">
 	</div>

--- a/wp-content/themes/gijn/inc/options.php
+++ b/wp-content/themes/gijn/inc/options.php
@@ -10,7 +10,7 @@ function gijn_custom_options($options) {
 		'type' => 'heading'
 	);
 	$options[] = array(
-		'desc' => __('<strong>Google Maps API key</strong> (Used for geocoding member locations, for <a href="https://gijn.org/member/">gijn.org/member</a>https://po.missouri.edu/cgi-bin/wa?A0=GLOBAL-L)', 'gijn'),
+		'desc' => __('<strong>Google Maps API key</strong> (Used for geocoding member locations, for <a href="https://gijn.org/member/">gijn.org/member</a>)', 'gijn'),
 		'id'   => 'google_maps_api_key',
 		'std'  => '',
 		'type' => 'text'


### PR DESCRIPTION


## Changes

- Replaces WordPress' get_option with Largo's of_get_option for an option set via the options framework.

## Why

Fix for https://secure.helpscout.net/conversation/883042956/3799/?folderId=1211654

## Testing/Questions

Features that this PR affects:

- https://gijn.org/member

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] does the map API key on gijn.org/members match the new API key?

Steps to test this PR:

1. deploy to prod
2. check the API key in use - it should not end in `Tuw`.

## Additional information

INN Member/Labs Client requesting: GIJN